### PR TITLE
Fix logo on mobile: remove img style

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -106,11 +106,6 @@ const UniIcon = styled.div`
   :hover {
     transform: rotate(-5deg);
   }
-  ${({ theme }) => theme.mediaWidth.upToSmall`
-    img { 
-      width: 0.25rem;
-    }
-  `};
 `
 
 const HeaderControls = styled.div`


### PR DESCRIPTION
Fix #2 

Hello @thebaoman I think we can remove this style here to fix:
https://github.com/baofinance/baoswap-ui-source/blob/da070829f6d5e40d3eec2a00fa76b1ffd95a585a/src/components/Header/index.tsx#L109-L113

![LogoBug](https://user-images.githubusercontent.com/18475870/108109189-2c24b180-7057-11eb-8b0e-1c8fbf57775d.gif)



###### Donate Bao 0x047C9678BF11753f028735e602bB34FEe3A742AD
![image](https://user-images.githubusercontent.com/18475870/108159434-a6cbec00-70ac-11eb-9fcd-7c751b4151b7.png)

